### PR TITLE
Support camelCase svg tags

### DIFF
--- a/can-view-parser.js
+++ b/can-view-parser.js
@@ -57,6 +57,9 @@ var block = makeMap("a,address,article,applet,aside,audio,blockquote,button,canv
 // Inline Elements - HTML 5
 var inline = makeMap("a,abbr,acronym,applet,b,basefont,bdo,big,br,button,cite,code,del,dfn,em,font,i,iframe,img,input,ins,kbd,label,map,object,q,s,samp,script,select,small,span,strike,strong,sub,sup,textarea,tt,u,var");
 
+// Elements for which tag case matters - shouldn't be lowercased.
+var caseMatters = makeMap("altGlyph,altGlyphDef,altGlyphItem,animateColor,animateMotion,animateTransform,clipPath,feBlend,feColorMatrix,feComponentTransfer,feComposite,feConvolveMatrix,feDiffuseLighting,feDisplacementMap,feDistantLight,feFlood,feFuncA,feFuncB,feFuncG,feFuncR,feGaussianBlur,feImage,feMerge,feMergeNode,feMorphology,feOffset,fePointLight,feSpecularLighting,feSpotLight,feTile,feTurbulence,foreignObject,glyphRef,linearGradient,radialGradient,textPath");
+
 // Elements that you can, intentionally, leave open
 // (and which close themselves)
 var closeSelf = makeMap("colgroup,dd,dt,li,options,p,td,tfoot,th,thead,tr");
@@ -90,9 +93,8 @@ var HTMLParser = function (html, handler, returnIntermediate) {
 		});
 	}
 
-
 	function parseStartTag(tag, tagName, rest, unary) {
-		tagName = tagName.toLowerCase();
+		tagName = caseMatters[tagName] ? tagName : tagName.toLowerCase();
 
 		if (block[tagName] && !inline[tagName]) {
 			var last = stack.last();
@@ -131,7 +133,7 @@ var HTMLParser = function (html, handler, returnIntermediate) {
 
 			// Find the closest opened tag of the same type
 		else {
-			tagName = tagName.toLowerCase();
+			tagName = caseMatters[tagName] ? tagName : tagName.toLowerCase();
 			for (pos = stack.length - 1; pos >= 0; pos--) {
 				if (stack[pos] === tagName) {
 					break;

--- a/test/can-view-parser-test.js
+++ b/test/can-view-parser-test.js
@@ -92,6 +92,26 @@ test("uppercase html to html", function(){
 
 });
 
+test("camelCase tags stay untouched (svg)", function(){
+
+
+
+	var tests = [
+		['start', ['svg', false]],
+		['end', ['svg', false]],
+		['start', ['radialGradient', false]],
+		['end', ['radialGradient', false]],
+		['close', ['radialGradient']],
+		['close', ['svg']],
+		['done', []]
+	];
+
+
+
+	parser("<svg><radialGradient></radialGradient></svg>", makeChecks(tests));
+
+});
+
 test("special in an attribute in an in-tag section", function(){
 
 	parser("<div {{#truthy}}foo='{{baz}}'{{/truthy}}></div>",makeChecks([


### PR DESCRIPTION
This adds another map for all of the svg tags that require camelCasing.  Taken from this page: https://developer.mozilla.org/en-US/docs/Web/SVG/Element

Also includes a passing test for radialGradient.

related to canjs/canjs#2418