### PR TITLE
Fix #13 (Provide warnings (or just make work) camel-cased attribute names for bindings)

### DIFF
--- a/test/can-view-parser-test.js
+++ b/test/can-view-parser-test.js
@@ -412,3 +412,11 @@ test('quotes around attributes and other lazy attribute writing (#2097)', functi
 		["done",[]]
 	]));
 });
+
+test('camelCased attributes are converted to spinal-case', function () {
+	parser.parseAttrs("({camelCase})='assigned'", makeChecks([
+		["attrStart", ["({camel-case})"]],
+		["attrValue", ["assigned"]],
+		["attrEnd", ["({camel-case})"]],
+	]));
+});


### PR DESCRIPTION
When parsing an attribute, test if the attribute name is camelCased. If yes, convert it to spinal-case and warn the user about the conversion.