### PR TITLE
Provide warnings for miss-matched starting and ending tags

### DIFF
--- a/can-view-parser.js
+++ b/can-view-parser.js
@@ -29,7 +29,7 @@ var alphaNumeric = "A-Za-z0-9",
 	camelCase = /([a-z])([A-Z])/g,
 	defaultMagicStart = "{{",
 	endTag = new RegExp("^<\\/(["+alphaNumericHU+"]+)[^>]*>"),
-	defaultMagicMatch = new RegExp("\\{\\{([^\\}]*)\\}\\}\\}?","g"),
+	defaultMagicMatch = new RegExp("\\{\\{([\\s\\S]*?)\\}\\}\\}?","g"),
 	space = /\s/,
 	alphaRegex = new RegExp('['+ alphaNumeric + ']');
 

--- a/can-view-parser.js
+++ b/can-view-parser.js
@@ -74,14 +74,6 @@ var HTMLParser = function (html, handler, returnIntermediate) {
 	var magicMatch = handler.magicMatch || defaultMagicMatch,
 		magicStart = handler.magicStart || defaultMagicStart;
 
-	function warn(message) {
-		if (handler.warn) {
-			handler.warn(message);
-		} else {
-			console.warn(message);
-		}
-	}
-
 	function parseStartTag(tag, tagName, rest, unary) {
 		tagName = caseMattersElements[tagName] ? tagName : tagName.toLowerCase();
 
@@ -120,17 +112,19 @@ var HTMLParser = function (html, handler, returnIntermediate) {
 			}
 		}
 
+		//!steal-remove-start
 		if (typeof tag === 'undefined') {
 			if (stack.length > 0) {
-				warn(`expected closing tag </${stack[pos]}>`);
+				dev.warn("expected closing tag </" + stack[pos] + ">");
 			}
 		} else if (pos < 0 || pos !== stack.length - 1) {
 			if (stack.length > 0) {
-				warn(`unexpected closing tag ${tag} expected </${stack[stack.length - 1]}>`);
+				dev.warn("unexpected closing tag " + tag + " expected </" + stack[stack.length - 1] + ">");
 			} else {
-				warn(`unexpected closing tag ${tag}`);
+				dev.warn("unexpected closing tag " + tag);
 			}
 		}
+		//!steal-remove-end
 
 		if (pos >= 0) {
 			// Close all the open elements, up the stack

--- a/can-view-parser.js
+++ b/can-view-parser.js
@@ -74,6 +74,14 @@ var HTMLParser = function (html, handler, returnIntermediate) {
 	var magicMatch = handler.magicMatch || defaultMagicMatch,
 		magicStart = handler.magicStart || defaultMagicStart;
 
+	function warn(message) {
+		if (handler.warn) {
+			handler.warn(message);
+		} else {
+			console.warn(message);
+		}
+	}
+
 	function parseStartTag(tag, tagName, rest, unary) {
 		tagName = caseMattersElements[tagName] ? tagName : tagName.toLowerCase();
 
@@ -109,6 +117,18 @@ var HTMLParser = function (html, handler, returnIntermediate) {
 				if (stack[pos] === tagName) {
 					break;
 				}
+			}
+		}
+
+		if (typeof tag === 'undefined') {
+			if (stack.length > 0) {
+				warn(`expected closing tag </${stack[pos]}>`);
+			}
+		} else if (pos < 0 || pos !== stack.length - 1) {
+			if (stack.length > 0) {
+				warn(`unexpected closing tag ${tag} expected </${stack[stack.length - 1]}>`);
+			} else {
+				warn(`unexpected closing tag ${tag}`);
 			}
 		}
 

--- a/test/can-view-parser-test.js
+++ b/test/can-view-parser-test.js
@@ -1,5 +1,6 @@
 var parser = require('can-view-parser');
 var QUnit = require('steal-qunit');
+var canDev = require('can-util/js/dev/dev');
 
 QUnit.module("can-view-parser");
 
@@ -507,43 +508,56 @@ test('{{}} in attribute values are handled correctly (#34)', function () {
 });
 
 test('warn on missmatched tag (canjs/canjs#1476)', function() {
-	var makeWarnChecks = function(tests) {
+	var makeWarnChecks = function(input, texts) {
 		var count = 0;
+		var _warn = canDev.warn;
+		canDev.warn = function(text) {
+			equal(text, texts[count++]);
+		};
 
-		return {
+		parser(input, {
 			start: function(tagName, unary) {},
 			end: function(tagName, unary) {},
-			done: function() {},
-			warn: function(message) {
-				if (count >= tests.length) {
-					ok(false, "received warning: " + message);
-				} else {
-					equal(message, tests[count]);
-					count++;
-				}
-			}
-		};
+			done: function() {}
+		});
+
+		equal(count, texts.length);
+
+		canDev.warn = _warn;
 	};
 
-	expect(7 + 6);
-	parser("</h2><h1>Header<span></span></h1><div></div>", makeWarnChecks([ "unexpected closing tag </h2>" ]));
-	parser("<h1>Header</h2><span></span></h1><div></div>", makeWarnChecks([ "unexpected closing tag </h2> expected </h1>" ]));
-	parser("<h1>Header<span></h2></span></h1><div></div>", makeWarnChecks([ "unexpected closing tag </h2> expected </span>" ]));
-	parser("<h1>Header<span></span></h2></h1><div></div>", makeWarnChecks([ "unexpected closing tag </h2> expected </h1>" ]));
-	parser("<h1>Header<span></span></h1></h2><div></div>", makeWarnChecks([ "unexpected closing tag </h2>" ]));
-	parser("<h1>Header<span></span></h1><div></h2></div>", makeWarnChecks([ "unexpected closing tag </h2> expected </div>" ]));
-	parser("<h1>Header<span></span></h1><div></div></h2>", makeWarnChecks([ "unexpected closing tag </h2>" ]));
+	makeWarnChecks("</h2><h1>Header<span></span></h1><div></div>", [
+		"unexpected closing tag </h2>"
+	]);
+	makeWarnChecks("<h1>Header</h2><span></span></h1><div></div>", [
+		"unexpected closing tag </h2> expected </h1>"
+	]);
+	makeWarnChecks("<h1>Header<span></h2></span></h1><div></div>", [
+		"unexpected closing tag </h2> expected </span>"
+	]);
+	makeWarnChecks("<h1>Header<span></span></h2></h1><div></div>", [
+		"unexpected closing tag </h2> expected </h1>"
+	]);
+	makeWarnChecks("<h1>Header<span></span></h1></h2><div></div>", [
+		"unexpected closing tag </h2>"
+	]);
+	makeWarnChecks("<h1>Header<span></span></h1><div></h2></div>", [
+		"unexpected closing tag </h2> expected </div>"
+	]);
+	makeWarnChecks("<h1>Header<span></span></h1><div></div></h2>", [
+		"unexpected closing tag </h2>"
+	]);
 
-	parser("<h1>Header<span></h2></h1><div></div>",   makeWarnChecks([
+	makeWarnChecks("<h1>Header<span></h2></h1><div></div>", [
 		"unexpected closing tag </h2> expected </span>",
 		"unexpected closing tag </h1> expected </span>"
-	]));
-	parser("<h1>Header<span></span></h2><div></div>", makeWarnChecks([
+	]);
+	makeWarnChecks("<h1>Header<span></span></h2><div></div>", [
 		"unexpected closing tag </h2> expected </h1>",
 		"expected closing tag </h1>"
-	]));
-	parser("<h1>Header<span></span></h1><div></h2>",  makeWarnChecks([
+	]);
+	makeWarnChecks("<h1>Header<span></span></h1><div></h2>", [
 		"unexpected closing tag </h2> expected </div>",
 		"expected closing tag </div>"
-	]));
+	]);
 });

--- a/test/can-view-parser-test.js
+++ b/test/can-view-parser-test.js
@@ -561,3 +561,20 @@ test('warn on missmatched tag (canjs/canjs#1476)', function() {
 		"expected closing tag </div>"
 	]);
 });
+
+test('tags with data attributes are allowed in comments (#2)', function() {
+	parser("{{! foo }}", makeChecks([
+		[ "special", [ "! foo " ] ],
+		[ "done", [] ]
+	]));
+
+	parser("{{! <foo /> }}", makeChecks([
+		[ "special", [ "! <foo /> " ] ],
+		[ "done", [] ]
+	]));
+
+	parser("{{! <foo bar=\"{bam}\" /> }}", makeChecks([
+		[ "special", [ "! <foo bar=\"{bam}\" /> " ] ],
+		[ "done", [] ]
+	]));
+});


### PR DESCRIPTION
Part of fix for canjs/can-stache#13 and canjs/canjs#1476. Added warnings for missmatched and unclosed tags.