### PR TITLE
fix magic regex to allow tags and newlines

### DIFF
--- a/can-view-parser.js
+++ b/can-view-parser.js
@@ -29,7 +29,7 @@ var alphaNumeric = "A-Za-z0-9",
 	camelCase = /([a-z])([A-Z])/g,
 	defaultMagicStart = "{{",
 	endTag = new RegExp("^<\\/(["+alphaNumericHU+"]+)[^>]*>"),
-	defaultMagicMatch = new RegExp("\\{\\{([^\\}]*)\\}\\}\\}?","g"),
+	defaultMagicMatch = new RegExp("\\{\\{([\\s\\S]*?)\\}\\}\\}?","g"),
 	space = /\s/,
 	alphaRegex = new RegExp('['+ alphaNumeric + ']');
 

--- a/test/can-view-parser-test.js
+++ b/test/can-view-parser-test.js
@@ -505,3 +505,20 @@ test('{{}} in attribute values are handled correctly (#34)', function () {
 
 	parser("<h1 class='{{foo}}a'></h1>", makeChecks(tests));
 });
+
+test('tags with data attributes are allowed in comments (#2)', function() {
+	parser("{{! foo }}", makeChecks([
+		[ "special", [ "! foo " ] ],
+		[ "done", [] ]
+	]));
+
+	parser("{{! <foo /> }}", makeChecks([
+		[ "special", [ "! <foo /> " ] ],
+		[ "done", [] ]
+	]));
+
+	parser("{{! <foo bar=\"{bam}\" /> }}", makeChecks([
+		[ "special", [ "! <foo bar=\"{bam}\" /> " ] ],
+		[ "done", [] ]
+	]));
+});


### PR DESCRIPTION
Fix for #2, allowing tags with data attributes in comments. (The specific block was any `}` in the comment body.) The `defaultMagicMatch` regex was looking for any character not `}` (`[^}]`) as the comment body. I switched it out for any character (`.`) and made it not greedy, so as to keep the same behaviour. Unfortunately, `.` cannot match a newline in javascript (some regex's allow a flag to enable this, but javascript does not). The most performant fix is to match any whitespace character or non-whitespace character (`[\s\S]`).

A quick performance test shows that this is a slight gain (around 1-2%) for comments not containing `}`, a large gain (23%) for long comments (tested 26 characters) contaning `}`, and only being slower for short comments (tested 7 characters) containing `}`.