### PR TITLE
add multiline special comments

### DIFF
--- a/can-view-parser.js
+++ b/can-view-parser.js
@@ -29,7 +29,7 @@ var alphaNumeric = "A-Za-z0-9",
 	camelCase = /([a-z])([A-Z])/g,
 	defaultMagicStart = "{{",
 	endTag = new RegExp("^<\\/(["+alphaNumericHU+"]+)[^>]*>"),
-	defaultMagicMatch = new RegExp("\\{\\{([\\s\\S]*?)\\}\\}\\}?","g"),
+	defaultMagicMatch = new RegExp("\\{\\{(![\\s\\S]*?!|[\\s\\S]*?)\\}\\}\\}?","g"),
 	space = /\s/,
 	alphaRegex = new RegExp('['+ alphaNumeric + ']');
 

--- a/test/can-view-parser-test.js
+++ b/test/can-view-parser-test.js
@@ -578,3 +578,20 @@ test('tags with data attributes are allowed in comments (#2)', function() {
 		[ "done", [] ]
 	]));
 });
+
+test('multiline special comments (#14)', function() {
+	parser("{{! foo !}}", makeChecks([
+		[ "special", [ "! foo !" ] ],
+		[ "done", [] ]
+	]));
+
+	parser("{{! {{foo}} {{bar}} !}}", makeChecks([
+		[ "special", [ "! {{foo}} {{bar}} !" ] ],
+		[ "done", [] ]
+	]));
+
+	parser("{{!\n{{foo}}\n{{bar}}\n!}}", makeChecks([
+		[ "special", [ "!\n{{foo}}\n{{bar}}\n!" ] ],
+		[ "done", [] ]
+	]));
+});


### PR DESCRIPTION
Modifies the magic tag match regex to allow multiline comments with embedded magic tags. In order to access these expanded comments, you must include the closing `!`. Allows the following extra syntaxes:

```javascript
{{! {{foo}} {{bar}} !}}
```

```javascript
{{!
<div>{{foo}}</div>
<div>{{bar}}</div>
!}}
```

fixes #14