### PR TITLE
#36 Sanitize attr values when parsing start tag so that special character…

### DIFF
--- a/can-view-parser.js
+++ b/can-view-parser.js
@@ -307,6 +307,21 @@ var camelCaseToSpinalCase = function (match, lowerCaseChar, upperCaseChar) {
 	return lowerCaseChar + "-" + upperCaseChar.toLowerCase();
 };
 
+HTMLParser.sanitizeAttrs = function(html) {
+	// represent:
+	// <tag attrs="special characters that can muck up parsing"></tag>
+	// as:
+	// <tag attrs=.............................................></tag>
+	//
+	// regex explanation:
+	// (['"]) capture an opening ' or "
+	// (?:(?!\1).)* match zero or more characters that aren't the captured ' or "
+	// \1 match the closing ' or "
+	return html.replace(/(['"])(?:(?!\1).)*\1/g, function(match) {
+		return Array(match.length + 1).join('.'); // works in MS-IE
+	});
+};
+
 HTMLParser.parseAttrs = function(rest, handler){
 	if(!rest) {
 		return;
@@ -435,7 +450,7 @@ HTMLParser.parseAttrs = function(rest, handler){
 };
 
 HTMLParser.searchStartTag = function (html) {
-	var closingIndex = html.indexOf('>');
+	var closingIndex = HTMLParser.sanitizeAttrs(html).indexOf('>');
 	// if there is no closing bracket
 	// <input class=
 	// or if the tagName does not start with alphaNumer character

--- a/test/can-view-parser-test.js
+++ b/test/can-view-parser-test.js
@@ -580,3 +580,25 @@ test('tags with data attributes are allowed in comments (#2)', function() {
 		[ "done", [] ]
 	]));
 });
+
+test('> in an attribute is correctly parsed (#36)', function() {
+	var tests = [
+		["start", ["div", false]], // <div foo=">"><hr foo=">" bar='>>->' /></div>
+		["attrStart", ["foo"]],
+		["attrValue", [">"]],
+		["attrEnd", ["foo"]],
+		["end", ["div", false]],
+			["start", ["hr", true]], // <hr foo="'>'" bar='>>->' /></div>
+			["attrStart", ["foo"]],
+			["attrValue", ["'>'"]],
+			["attrEnd", ["foo"]],
+			["attrStart", ["bar"]],
+			["attrValue", [">>->"]],
+			["attrEnd", ["bar"]],
+			["end", ["hr", true]],
+		["close", ["div"]],
+		["done", []]
+	];
+
+	parser('<div foo=">"><hr foo="\'>\'" bar=\'>>->\' /></div>', makeChecks(tests));
+});


### PR DESCRIPTION
…s like ">", that may be present in attribute values, do not affect parsing. Resolves #36