### PR TITLE
allow and encode spaces in attribute names that start with `{` or `(`

### DIFF
--- a/can-view-parser.js
+++ b/can-view-parser.js
@@ -31,6 +31,7 @@ var alphaNumeric = "A-Za-z0-9",
 	endTag = new RegExp("^<\\/(["+alphaNumericHU+"]+)[^>]*>"),
 	defaultMagicMatch = new RegExp("\\{\\{([\\s\\S]*?)\\}\\}\\}?","g"),
 	space = /\s/,
+	spacesRegex = new RegExp("\\s", "g"),
 	alphaRegex = new RegExp('['+ alphaNumeric + ']');
 
 // Empty Elements - HTML 5
@@ -270,6 +271,12 @@ var callAttrStart = function(state, curIndex, handler, rest){
 		dev.warn("can-view-parser: Found attribute with name: ", oldAttrName, ". Converting to: ", newAttrName);
 		//!steal-remove-end
 	}
+
+	//encode spaces
+	if(spacesRegex.test(attrName)){
+		newAttrName = attrName.replace(spacesRegex, "\\s");
+	}
+
 	state.attrStart = newAttrName;
 	handler.attrStart(state.attrStart);
 	state.inName = false;
@@ -314,7 +321,7 @@ HTMLParser.parseAttrs = function(rest, handler){
 
 	var magicMatch = handler.magicMatch || defaultMagicMatch,
 		magicStart = handler.magicStart || defaultMagicStart;
-
+  
 	var i = 0;
 	var curIndex;
 	var state = {
@@ -328,6 +335,9 @@ HTMLParser.parseAttrs = function(rest, handler){
 		lookingForValue: false,
 		lookingForEq : false
 	};
+	//maps end characters to start characters
+	var startOppositesMap = {"{": "}", "(":")"};
+
 	while(i < rest.length) {
 		curIndex = i;
 		var cur = rest.charAt(i);
@@ -377,22 +387,25 @@ HTMLParser.parseAttrs = function(rest, handler){
 			// if we haven't yet started this attribute `{{}}=foo` case:
 			if(!state.attrStart) {
 				callAttrStart(state, curIndex, handler, rest);
-
-				// if the equal sign is the last character
-				// we need to end the attribute
-				if(i === rest.length){
-					callAttrEnd(state, curIndex, handler, rest);
-				}
 			}
 			state.lookingForValue = true;
 			state.lookingForEq = false;
 			state.lookingForName = false;
 		}
-		// if we are currently in a name, check if we found a space
+		
+		// if we are currently in a name:
+		//  when the name starts with `{` or `)`
+		//  it isn't finished until the matching end character is found
+		//  otherwise, a space finishes the name
 		else if(state.inName) {
-			if(space.test(cur)) {
-				callAttrStart(state, curIndex, handler, rest);
+			var started = rest[ state.nameStart ];
+			if(startOppositesMap[started] === cur) {
+				callAttrStart(state, curIndex+1, handler, rest);
 				state.lookingForEq = true;
+			} 
+			else if(space.test(cur) && started !== "{" && started !== "(") {
+					callAttrStart(state, curIndex, handler, rest);
+					state.lookingForEq = true;
 			}
 		}
 		else if(state.lookingForName) {
@@ -426,9 +439,7 @@ HTMLParser.parseAttrs = function(rest, handler){
 	if(state.inName) {
 		callAttrStart(state, curIndex+1, handler, rest);
 		callAttrEnd(state, curIndex+1, handler, rest);
-	} else if(state.lookingForEq) {
-		callAttrEnd(state, curIndex+1, handler, rest);
-	} else if(state.inValue) {
+	} else if(state.lookingForEq || state.lookingForValue || state.inValue) {
 		callAttrEnd(state, curIndex+1, handler, rest);
 	}
 	magicMatch.lastIndex = 0;

--- a/can-view-parser.js
+++ b/can-view-parser.js
@@ -31,7 +31,7 @@ var alphaNumeric = "A-Za-z0-9",
 	endTag = new RegExp("^<\\/(["+alphaNumericHU+"]+)[^>]*>"),
 	defaultMagicMatch = new RegExp("\\{\\{([\\s\\S]*?)\\}\\}\\}?","g"),
 	space = /\s/,
-	spacesRegex = new RegExp("\\s", "g"),
+	spacesRegex = /\s/g,
 	alphaRegex = new RegExp('['+ alphaNumeric + ']');
 
 // Empty Elements - HTML 5
@@ -52,6 +52,9 @@ var special = makeMap("script");
 
 // Callback names on `handler`.
 var tokenTypes = "start,end,close,attrStart,attrEnd,attrValue,chars,comment,special,done".split(",");
+
+//maps end characters to start characters
+var startOppositesMap = {"{": "}", "(":")"};
 
 var fn = function(){};
 
@@ -273,9 +276,7 @@ var callAttrStart = function(state, curIndex, handler, rest){
 	}
 
 	//encode spaces
-	if(spacesRegex.test(attrName)){
-		newAttrName = attrName.replace(spacesRegex, "\\s");
-	}
+	newAttrName = newAttrName.replace(spacesRegex, "\\s");
 
 	state.attrStart = newAttrName;
 	handler.attrStart(state.attrStart);
@@ -335,8 +336,6 @@ HTMLParser.parseAttrs = function(rest, handler){
 		lookingForValue: false,
 		lookingForEq : false
 	};
-	//maps end characters to start characters
-	var startOppositesMap = {"{": "}", "(":")"};
 
 	while(i < rest.length) {
 		curIndex = i;

--- a/can-view-parser.js
+++ b/can-view-parser.js
@@ -397,9 +397,20 @@ HTMLParser.parseAttrs = function(rest, handler){
 		//  it isn't finished until the matching end character is found
 		//  otherwise, a space finishes the name
 		else if(state.inName) {
-			var started = rest[ state.nameStart ];
+			var started = rest[ state.nameStart ],
+					otherStart, otherOpposite;
 			if(startOppositesMap[started] === cur) {
-				callAttrStart(state, curIndex+1, handler, rest);
+				//handle mismatched brackets: `{(})` or `({)}`
+				otherStart = started === "{" ? "(" : "{";
+				otherOpposite = startOppositesMap[otherStart];
+				
+				if(rest[curIndex+1] === otherOpposite){
+					callAttrStart(state, curIndex+2, handler, rest);
+					i++;
+				}else{
+					callAttrStart(state, curIndex+1, handler, rest);
+				}
+
 				state.lookingForEq = true;
 			} 
 			else if(space.test(cur) && started !== "{" && started !== "(") {

--- a/test/can-view-parser-test.js
+++ b/test/can-view-parser-test.js
@@ -609,3 +609,31 @@ test('for attributes without values, spaces in attribute names that start with `
 
 	parser("<h1 {foo } {bar }></h1>", makeChecks(tests));
 });
+
+test('mismatched brackets work: {(foo})', function () {
+	var tests = [
+		["start", ["h1", false]],
+		["attrStart", ["{(foo})"]],
+		["attrValue", ["a"]],
+		["attrEnd", ["{(foo})"]],
+		["end", ["h1", false]],
+		["close",["h1"]],
+		["done",[]]
+	];
+
+	parser("<h1 {(foo})='a'></h1>", makeChecks(tests));
+});
+
+test('mismatched brackets work: ({foo)}', function () {
+	var tests = [
+		["start", ["h1", false]],
+		["attrStart", ["({foo)}"]],
+		["attrValue", ["a"]],
+		["attrEnd", ["({foo)}"]],
+		["end", ["h1", false]],
+		["close",["h1"]],
+		["done",[]]
+	];
+
+	parser("<h1 ({foo)}='a'></h1>", makeChecks(tests));
+});

--- a/test/can-view-parser-test.js
+++ b/test/can-view-parser-test.js
@@ -580,3 +580,32 @@ test('tags with data attributes are allowed in comments (#2)', function() {
 		[ "done", [] ]
 	]));
 });
+
+test('spaces in attribute names that start with `{` or `(` are encoded (#48)', function () {
+	var tests = [
+		["start", ["h1", false]],
+		["attrStart", ["{foo\\sbar}"]],
+		["attrValue", ["a"]],
+		["attrEnd", ["{foo\\sbar}"]],
+		["end", ["h1", false]],
+		["close",["h1"]],
+		["done",[]]
+	];
+
+	parser("<h1 {foo bar}='a'></h1>", makeChecks(tests));
+});
+
+test('for attributes without values, spaces in attribute names that start with `{` or `(` are encoded (#48)', function () {
+	var tests = [
+		["start", ["h1", false]],
+		["attrStart", ["{foo\\s}"]],
+		["attrEnd", ["{foo\\s}"]],
+		["attrStart", ["{bar\\s}"]],
+		["attrEnd", ["{bar\\s}"]],
+		["end", ["h1", false]],
+		["close",["h1"]],
+		["done",[]]
+	];
+
+	parser("<h1 {foo } {bar }></h1>", makeChecks(tests));
+});


### PR DESCRIPTION
fixes #48 