### PR TITLE
encoding camelCase properties following `on:`

### DIFF
--- a/can-view-parser.js
+++ b/can-view-parser.js
@@ -33,7 +33,8 @@ var alphaNumeric = "A-Za-z0-9",
 	space = /\s/,
 	spacesRegex = /\s/g,
 	alphaRegex = new RegExp('['+ alphaNumeric + ']'),
-	forwardSlashRegex = /\//g;
+	forwardSlashRegex = /\//g,
+	capitalLetterRegex = /[A-Z]/g;
 
 // Empty Elements - HTML 5
 var empty = makeMap("area,base,basefont,br,col,frame,hr,img,input,isindex,link,meta,param,embed");
@@ -269,11 +270,21 @@ var callAttrStart = function(state, curIndex, handler, rest){
 	var attrName = rest.substring(typeof state.nameStart === "number" ? state.nameStart : curIndex, curIndex),
 		newAttrName = attrName,
 		oldAttrName = attrName;
+
 	if (!caseMattersAttributes[attrName] && camelCase.test(attrName)) {
-		newAttrName = attrName.replace(camelCase, camelCaseToSpinalCase);
-		//!steal-remove-start
-		dev.warn("can-view-parser: Found attribute with name: ", oldAttrName, ". Converting to: ", newAttrName);
-		//!steal-remove-end
+		// if attrname starts with `on:`, encode capital letters
+		// to allow `on:fooBar` but prevent `(fooBar)`, which is not supported
+		if (attrName.indexOf('on:') === 0) {
+			newAttrName = attrName
+				.replace(capitalLetterRegex, function(char) {
+					return '\\c' + char.toLowerCase();
+				});
+		} else {
+			newAttrName = attrName.replace(camelCase, camelCaseToSpinalCase);
+			//!steal-remove-start
+			dev.warn("can-view-parser: Found attribute with name: ", oldAttrName, ". Converting to: ", newAttrName);
+			//!steal-remove-end
+		}
 	}
 
 	//encode spaces

--- a/test/can-view-parser-test.js
+++ b/test/can-view-parser-test.js
@@ -671,3 +671,17 @@ test('forward slashes are encoded (#52)', function () {
 
 	parser("<h1 {foo/bar}='a'></h1>", makeChecks(tests));
 });
+
+test('camelCase properties following on: are encoded', function () {
+	var tests = [
+		["start", ["h1", false]],
+		["attrStart", ["on:foo\\cbar"]],
+		["attrValue", ["a"]],
+		["attrEnd", ["on:foo\\cbar"]],
+		["end", ["h1", false]],
+		["close",["h1"]],
+		["done",[]]
+	];
+
+	parser("<h1 on:fooBar='a'></h1>", makeChecks(tests));
+});


### PR DESCRIPTION
closes https://github.com/canjs/can-view-parser/issues/60.