### PR TITLE
Support closing bracket character (>) in attribute values

### DIFF
--- a/can-view-parser.js
+++ b/can-view-parser.js
@@ -38,7 +38,8 @@ var alphaNumeric = "A-Za-z0-9",
 	endTag = new RegExp("^<\\/(["+alphaNumericHU+"]+)[^>]*>"),
 	defaultMagicMatch = new RegExp("\\{\\{(![\\s\\S]*?!|[\\s\\S]*?)\\}\\}\\}?","g"),
 	space = /\s/,
-	alphaRegex = new RegExp('['+ alphaNumeric + ']');
+	alphaRegex = new RegExp('['+ alphaNumeric + ']'),
+	attributeRegexp = new RegExp("["+alphaNumericHU+"]+\s*=\s*(\"[^\"]*\"|'[^']*')");
 
 // Empty Elements - HTML 5
 var empty = makeMap("area,base,basefont,br,col,frame,hr,img,input,isindex,link,meta,param,embed");
@@ -538,6 +539,26 @@ HTMLParser.parseAttrs = function(rest, handler, lineNo){
 
 HTMLParser.searchStartTag = function (html) {
 	var closingIndex = html.indexOf('>');
+
+	// The first closing bracket we find might be in an attribute value.
+	// Move through the attributes by regexp.
+	var attributeRange = attributeRegexp.exec(html.substring(1));
+	var afterAttributeOffset = 1;
+	// if the closing index is after the next attribute...
+	while(attributeRange && closingIndex >= afterAttributeOffset + attributeRange.index) {
+
+		// prepare to move to the attribute after this one by increasing the offset
+		afterAttributeOffset += attributeRange.index + attributeRange[0].length;
+		// if the closing index is before the new offset, then this closing index is inside
+		//  an attribute value and should be ignored.  Find the *next* closing character.
+		while(closingIndex < afterAttributeOffset) {
+			closingIndex += html.substring(closingIndex + 1).indexOf('>') + 1;
+		}
+
+		// find the next attribute by starting from the new offset.
+		attributeRange = attributeRegexp.exec(html.substring(afterAttributeOffset));
+	}
+
 	// if there is no closing bracket
 	// <input class=
 	// or if the tagName does not start with alphaNumer character

--- a/test/can-view-parser-test.js
+++ b/test/can-view-parser-test.js
@@ -509,6 +509,52 @@ test('{{}} in attribute values are handled correctly (#34)', function () {
 	parser("<h1 class='{{foo}}a'></h1>", makeChecks(tests));
 });
 
+test('> in attribute values are handled correctly', function() {
+	parser('<h1 data-content="<b>foo</b>">bar</h1>', makeChecks([
+		["start", ["h1", false]],
+		["attrStart", ["data-content"]],
+		["attrValue", ["<b>foo</b>"]],
+		["attrEnd", ["data-content"]],		//10
+		["end", ["h1", false]],
+		["chars", ["bar"]],
+		["close",["h1"]],
+		["done",[]]
+	]));
+
+	parser('<h1 data-nothing="" data-something="something" data-content="<b>foo</b>" data-something-after="something-after">bar</h1>', makeChecks([
+		["start", ["h1", false]],
+		["attrStart", ["data-nothing"]],
+		["attrEnd", ["data-nothing"]],		//10
+		["attrStart", ["data-something"]],
+		["attrValue", ["something"]],
+		["attrEnd", ["data-something"]],		//10
+		["attrStart", ["data-content"]],
+		["attrValue", ["<b>foo</b>"]],
+		["attrEnd", ["data-content"]],		//10
+		["attrStart", ["data-something-after"]],
+		["attrValue", ["something-after"]],
+		["attrEnd", ["data-something-after"]],		//10
+		["end", ["h1", false]],
+		["chars", ["bar"]],
+		["close",["h1"]],
+		["done",[]]
+	]));
+
+	parser('<h1 data-first="<b>foo</b>" \n data-second="><>>>>><foo>>>/>> \n />"  \n >\nbar</h1>', makeChecks([
+		["start", ["h1", false]],
+		["attrStart", ["data-first"]],
+		["attrValue", ["<b>foo</b>"]],
+		["attrEnd", ["data-first"]],		//10
+		["attrStart", ["data-second"]],
+		["attrValue", ["><>>>>><foo>>>/>> \n />"]],
+		["attrEnd", ["data-second"]],		//10
+		["end", ["h1", false]],
+		["chars", ["\nbar"]],
+		["close",["h1"]],
+		["done",[]]
+	]));
+});
+
 //!steal-remove-start
 test('counts lines properly', function() {
 	parser(`


### PR DESCRIPTION
Example:

`<span data-content="<b>foo</b>">bar</span>`

Previously this would end the attribute value just before the first `>`, and treat what came after the `>` as content.  This PR lets the start tag parser ignore these characters inside attribute values and parses the above correctly, with `span` as the tag name and `data-content="<b>foo</b>"` as the attribute name and value.