### PR TITLE
Avoid parsing TextNodes after html and body

### DIFF
--- a/can-view-parser.js
+++ b/can-view-parser.js
@@ -129,6 +129,9 @@ var HTMLParser = function (html, handler, returnIntermediate) {
 
 		handler.end(tagName, unary, lineNo);
 
+		if(tagName === "html") {
+			skipChars = true;
+		}
 	}
 
 	function parseEndTag(tag, tagName) {
@@ -188,6 +191,11 @@ var HTMLParser = function (html, handler, returnIntermediate) {
 
 			// Remove the open elements from the stack
 			stack.length = pos;
+
+			// Don't add TextNodes after the <body> tag
+			if(tagName === "body") {
+				skipChars = true;
+			}
 		}
 	}
 
@@ -198,7 +206,7 @@ var HTMLParser = function (html, handler, returnIntermediate) {
 	}
 
 	var callChars = function(){
-		if(charsText) {
+		if(charsText && !skipChars) {
 			if(handler.chars) {
 				handler.chars(charsText, lineNo);
 			}
@@ -210,11 +218,13 @@ var HTMLParser = function (html, handler, returnIntermediate) {
 			//!steal-remove-end
 		}
 
+		skipChars = false;
 		charsText = "";
 	};
 
 	var index,
 		chars,
+		skipChars,
 		match,
 		lineNo,
 		stack = [],
@@ -375,7 +385,7 @@ var callAttrEnd = function(state, curIndex, handler, rest, lineNo){
 			quotedVal = rest.substring(state.valueStart - 1, curIndex + 1);
 			quotedVal = quotedVal.trim();
 			closedQuote = quotedVal.charAt(quotedVal.length - 1);
-			
+
 			if (state.inQuote !== closedQuote) {
 				if (handler.filename) {
 					dev.warn(handler.filename + ":" + lineNo + ": End quote is missing for " + val);

--- a/test/can-view-parser-test.js
+++ b/test/can-view-parser-test.js
@@ -867,3 +867,36 @@ testHelpers.dev.devOnlyTest('Fix false warning on missing closed quote (canjs/ca
 	]);
 
 });
+
+test('TextNodes are not inserted before the <head> or after the </body>', function () {
+	var tests = [
+		["start", ["html", false]],
+		["end", ["html", false]],
+		//["chars", ["\n\t"]], // TODO REMOVE THIS
+		["start", ["head", false]],
+		["end", ["head", false]],
+		["chars", ["\n\t\t"]],
+		["start", ["title", false]],
+		["end", ["title", false]],
+		["chars", ["Test"]],
+		["close", ["title"]],
+		["chars", ["\n\t\t"]],
+		["close", ["head"]],
+		["chars", ["\n\t"]],
+		["start", ["body", false]],
+		["end", ["body", false]],
+		["chars", ["\n\t\t"]],
+		["start", ["h1", false]],
+		["end", ["h1", false]],
+		["chars", ["Test"]],
+		["close", ["h1"]],
+		["chars", ["\n\t"]],
+		["close", ["body"]],
+		//["chars", ["\n"]], // TODO REMOVE THIS
+		["close", ["html"]],
+		["done", []]
+	];
+
+	var html = "<html>\n\t<head>\n\t\t<title>Test</title>\n\t\t</head>\n\t<body>\n\t\t<h1>Test</h1>\n\t</body>\n</html>"
+	parser(html, makeChecks(tests));
+});


### PR DESCRIPTION
This prevents parsing of TextNodes after the html and body tags, as is
the case with browsers. Closes #97